### PR TITLE
Correct Confidence Percent Calculation

### DIFF
--- a/nodes/sensor.py
+++ b/nodes/sensor.py
@@ -127,7 +127,7 @@ class SensorNode(polyinterface.Node):
             A = float(channel_a['PM2_5Value'])
             B = float(channel_b['PM2_5Value'])
 
-            C = 100 - abs((A - B) / (A + B))
+            C = 100 - abs((A - B) / (100*(A + B)))
             return round(C, 0)
         else:
             LOGGER.error('missing data for PM2.5.')


### PR DESCRIPTION
Of course, of all the locations available, the closest one to me is the only one which has a significant difference between the 2 channels.  Just my luck.

I noted that the current calculation would return 100% even if Channel A had a value of 20 and Channel B had a value of 200.  Not the desired result.

Converted the fractional difference values to a whole value percentage

Example station with a current 89% confidence as reported by PurpleAir is station 8258

